### PR TITLE
Alternative logic for steering with head-roll

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1862,13 +1862,18 @@ void MyAvatar::updateOrientation(float deltaTime) {
 
     if (qApp->isHMDMode() && _hmdRollControlEnabled) {
 #ifdef USE_SIMPLE_ROLL_CONTROL
-        // Use head/HMD roll to turn while walking or flying.
-        glm::vec3 avatarUp = getOrientation() * IDENTITY_UP;
-        glm::vec3 rolledRight = getHeadOrientation() * IDENTITY_RIGHT;
-        float rolledRightDotUp = glm::dot(rolledRight, avatarUp);
-        const float MIN_ROLL_DOT_THRESHOLD = 0.1f; // ~5.72 degrees
-        if (fabsf(rolledRightDotUp) > MIN_ROLL_DOT_THRESHOLD) {
-            totalBodyYaw += rolledRightDotUp * deltaTime * _hmdRollControlSpeed;
+        float speed = glm::length(getVelocity());
+        const float MIN_CONTROL_SPEED = 0.01f;
+        if (speed >= MIN_CONTROL_SPEED) {
+            // Use head/HMD roll to turn while walking or flying.
+            glm::vec3 avatarUp = getOrientation() * IDENTITY_UP;
+            glm::vec3 rolledRight = getHeadOrientation() * IDENTITY_RIGHT;
+            float rolledRightDotUp = glm::dot(rolledRight, avatarUp);
+            const float MIN_ROLL_DOT_THRESHOLD = 0.15f;
+            if (fabsf(rolledRightDotUp) > MIN_ROLL_DOT_THRESHOLD) {
+                rolledRightDotUp -= (rolledRightDotUp > 0.0f) ? MIN_ROLL_DOT_THRESHOLD : - MIN_ROLL_DOT_THRESHOLD;
+                totalBodyYaw += rolledRightDotUp * deltaTime * _hmdRollControlSpeed;
+            }
         }
 #else // USE_SIMPLE_ROLL_CONTROL
         // Use head/HMD roll to turn while walking or flying.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1869,7 +1869,7 @@ void MyAvatar::updateOrientation(float deltaTime) {
             glm::vec3 avatarUp = getOrientation() * IDENTITY_UP;
             glm::vec3 rolledRight = getHeadOrientation() * IDENTITY_RIGHT;
             float rolledRightDotUp = glm::dot(rolledRight, avatarUp);
-            const float MIN_ROLL_DOT_THRESHOLD = 0.15f;
+            const float MIN_ROLL_DOT_THRESHOLD = 0.15f; // 0.15 corresponds to ~8.62 degrees
             if (fabsf(rolledRightDotUp) > MIN_ROLL_DOT_THRESHOLD) {
                 rolledRightDotUp -= (rolledRightDotUp > 0.0f) ? MIN_ROLL_DOT_THRESHOLD : - MIN_ROLL_DOT_THRESHOLD;
                 totalBodyYaw += rolledRightDotUp * deltaTime * _hmdRollControlSpeed;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -28,6 +28,8 @@
 #include "MyCharacterController.h"
 #include <ThreadSafeValueCache.h>
 
+#define USE_SIMPLE_ROLL_CONTROL
+
 class AvatarActionHold;
 class ModelItemID;
 class MyHead;
@@ -689,10 +691,13 @@ private:
     bool _hmdRollControlEnabled { true };
     float _hmdRollControlDeadZone { ROLL_CONTROL_DEAD_ZONE_DEFAULT };
     float _hmdRollControlSpeed { ROLL_CONTROL_SPEED_DEFAULT };
+#ifdef USE_SIMPLE_ROLL_CONTROL
+#else // USE_SIMPLE_ROLL_CONTROL
     glm::quat _hmdRollControlOrientation { glm::quat() };
     float _lastSpeed { 0.0f };
     float _lastPitch { 0.0f };
     float _lastDrivenSpeed { 0.0f };
+#endif // USE_SIMPLE_ROLL_CONTROL
 
     // working copies -- see AvatarData for thread-safe _sensorToWorldMatrixCache, used for outward facing access
     glm::mat4 _sensorToWorldMatrix { glm::mat4() };

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -687,7 +687,11 @@ private:
     bool _clearOverlayWhenMoving { true };
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // deg
+#ifdef USE_SIMPLE_ROLL_CONTROL
+    const float ROLL_CONTROL_SPEED_DEFAULT = 180.0f; // deg/sec
+#else // USE_SIMPLE_ROLL_CONTROL
     const float ROLL_CONTROL_SPEED_DEFAULT = 2.5f; // deg/sec/deg
+#endif // USE_SIMPLE_ROLL_CONTROL
     bool _hmdRollControlEnabled { true };
     float _hmdRollControlDeadZone { ROLL_CONTROL_DEAD_ZONE_DEFAULT };
     float _hmdRollControlSpeed { ROLL_CONTROL_SPEED_DEFAULT };


### PR DESCRIPTION
Intuition was telling me that there was a simpler alternative to keeping track of `_lastSpeed` and friends but I couldn't explain how to do it without actually trying it.  This is the result of that exploration.

Note: after trying the controls out myself (my version and the original) I found that the new feature doesn't actually work all that well for me.  The head controls the vertical component using pitch and adds yaw based on amplitude of roll (but only when the avatar is actually moving linearly), such that the head's actual yaw doesn't influence the body motion at all... most of the time.  However, there is logic elsewhere that is watching the head yaw and after some time of significant yaw it will actually reconcile that yaw by turning the body (and counter-adjusting the sensorToWorldMatrix at the same time).  This means that head yaw _will_ eventually turn the body for large yaw and when it happens it is unexpected and confusing.

In short, what Philip asked for is probably not what he actually wants.  If we merge PR-10617 then I would expect that "bug" will eventually be noticed and we'll have to fix it.  However, maybe that is the best way forward: make changes but be responsive when fixes are requested.